### PR TITLE
Added Trip details and polyline

### DIFF
--- a/TrackingApp.xcodeproj/project.pbxproj
+++ b/TrackingApp.xcodeproj/project.pbxproj
@@ -7,6 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		828545372CC996900074EBF9 /* TripMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545362CC996900074EBF9 /* TripMapViewController.swift */; };
+		828545382CC996900074EBF9 /* TripMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545362CC996900074EBF9 /* TripMapViewController.swift */; };
+		828545392CC996900074EBF9 /* TripMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545362CC996900074EBF9 /* TripMapViewController.swift */; };
+		8285453B2CC997210074EBF9 /* TripMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453A2CC997210074EBF9 /* TripMapViewModel.swift */; };
+		8285453C2CC997210074EBF9 /* TripMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453A2CC997210074EBF9 /* TripMapViewModel.swift */; };
+		8285453D2CC997210074EBF9 /* TripMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453A2CC997210074EBF9 /* TripMapViewModel.swift */; };
+		8285453F2CC997690074EBF9 /* TripStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453E2CC997690074EBF9 /* TripStatsView.swift */; };
+		828545402CC997690074EBF9 /* TripStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453E2CC997690074EBF9 /* TripStatsView.swift */; };
+		828545412CC997690074EBF9 /* TripStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285453E2CC997690074EBF9 /* TripStatsView.swift */; };
+		828545432CC9979D0074EBF9 /* TripAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545422CC9979D0074EBF9 /* TripAnnotation.swift */; };
+		828545442CC9979D0074EBF9 /* TripAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545422CC9979D0074EBF9 /* TripAnnotation.swift */; };
+		828545452CC9979D0074EBF9 /* TripAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545422CC9979D0074EBF9 /* TripAnnotation.swift */; };
+		828545472CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */; };
+		828545482CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */; };
+		828545492CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */; };
 		82C285882CC8E918000CF5F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C285872CC8E918000CF5F7 /* AppDelegate.swift */; };
 		82C2858A2CC8E918000CF5F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C285892CC8E918000CF5F7 /* SceneDelegate.swift */; };
 		82C2858F2CC8E918000CF5F7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82C2858D2CC8E918000CF5F7 /* Main.storyboard */; };
@@ -156,6 +171,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		828545362CC996900074EBF9 /* TripMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripMapViewController.swift; sourceTree = "<group>"; };
+		8285453A2CC997210074EBF9 /* TripMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripMapViewModel.swift; sourceTree = "<group>"; };
+		8285453E2CC997690074EBF9 /* TripStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripStatsView.swift; sourceTree = "<group>"; };
+		828545422CC9979D0074EBF9 /* TripAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripAnnotation.swift; sourceTree = "<group>"; };
+		828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataManager+Locations.swift"; sourceTree = "<group>"; };
 		82C285842CC8E918000CF5F7 /* TrackingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TrackingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82C285872CC8E918000CF5F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		82C285892CC8E918000CF5F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -343,6 +363,7 @@
 				82C285BC2CC8E9A4000CF5F7 /* MapViewModel.swift */,
 				82C285F52CC90466000CF5F7 /* MapViewModel+CoreData.swift */,
 				82C285CA2CC8EACD000CF5F7 /* TripsViewModel.swift */,
+				8285453A2CC997210074EBF9 /* TripMapViewModel.swift */,
 				82C285F72CC9048A000CF5F7 /* TripsViewModel+CoreData.swift */,
 				82C2860E2CC9154E000CF5F7 /* StatisticsViewModel.swift */,
 			);
@@ -356,6 +377,7 @@
 				82C286762CC971F4000CF5F7 /* AppLocationManager+Geofencing.swift */,
 				82C285F32CC90404000CF5F7 /* CoreDataManager.swift */,
 				82C286582CC95439000CF5F7 /* CoreDataManager+TransportationMode.swift */,
+				828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */,
 				82C2866F2CC97049000CF5F7 /* GeofencingService.swift */,
 				82C285D92CC8F26C000CF5F7 /* LocationPermissionAlert.swift */,
 				82C285D72CC8F1AC000CF5F7 /* LocationPermissionChecker.swift */,
@@ -368,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				82C285BE2CC8E9E4000CF5F7 /* MapViewController.swift */,
+				828545362CC996900074EBF9 /* TripMapViewController.swift */,
 				82C285C62CC8EAA0000CF5F7 /* TripsViewController.swift */,
 				82C286062CC90D03000CF5F7 /* TripsViewController+TripCell.swift */,
 				82C286142CC915BA000CF5F7 /* StatisticsViewController.swift */,
@@ -380,9 +403,11 @@
 			children = (
 				82C285C22CC8EA2F000CF5F7 /* SpeedView.swift */,
 				82C286172CC915FB000CF5F7 /* TripStatCardView.swift */,
+				8285453E2CC997690074EBF9 /* TripStatsView.swift */,
 				82C286502CC931C0000CF5F7 /* StatCardView.swift */,
 				82C286022CC90BE5000CF5F7 /* LoadingView.swift */,
 				82C286042CC90C09000CF5F7 /* EmptyStateView.swift */,
+				828545422CC9979D0074EBF9 /* TripAnnotation.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -574,7 +599,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				828545372CC996900074EBF9 /* TripMapViewController.swift in Sources */,
 				82C285C52CC8EA4B000CF5F7 /* MapCoordinator.swift in Sources */,
+				8285453B2CC997210074EBF9 /* TripMapViewModel.swift in Sources */,
 				82C285CB2CC8EACD000CF5F7 /* TripsViewModel.swift in Sources */,
 				82C286702CC97049000CF5F7 /* GeofencingService.swift in Sources */,
 				82C286152CC915BA000CF5F7 /* StatisticsViewController.swift in Sources */,
@@ -593,11 +620,14 @@
 				82C285EE2CC9038A000CF5F7 /* LocationEntity+CoreDataClass.swift in Sources */,
 				82C286772CC971F4000CF5F7 /* AppLocationManager+Geofencing.swift in Sources */,
 				82C285C92CC8EAB1000CF5F7 /* TripCoordinator.swift in Sources */,
+				828545432CC9979D0074EBF9 /* TripAnnotation.swift in Sources */,
 				82C285E82CC90330000CF5F7 /* TripEntity+CoreDataClass.swift in Sources */,
+				828545472CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */,
 				82C285F42CC90404000CF5F7 /* CoreDataManager.swift in Sources */,
 				82C285BD2CC8E9A4000CF5F7 /* MapViewModel.swift in Sources */,
 				82C286072CC90D03000CF5F7 /* TripsViewController+TripCell.swift in Sources */,
 				82C286622CC96A3C000CF5F7 /* TransportationModeDetectionService.swift in Sources */,
+				8285453F2CC997690074EBF9 /* TripStatsView.swift in Sources */,
 				82C285C32CC8EA2F000CF5F7 /* SpeedView.swift in Sources */,
 				82C285CD2CC8EAE2000CF5F7 /* TripEntity.swift in Sources */,
 				82C2865E2CC9599F000CF5F7 /* LoadingState.swift in Sources */,
@@ -631,14 +661,18 @@
 				82C286632CC96A3C000CF5F7 /* TransportationModeDetectionService.swift in Sources */,
 				82C286712CC97049000CF5F7 /* GeofencingService.swift in Sources */,
 				82C286212CC91C47000CF5F7 /* AppCoordinator.swift in Sources */,
+				828545442CC9979D0074EBF9 /* TripAnnotation.swift in Sources */,
 				82C286222CC91C5E000CF5F7 /* TripEntity.swift in Sources */,
 				82C286102CC9154E000CF5F7 /* StatisticsViewModel.swift in Sources */,
 				82C2862E2CC91CE9000CF5F7 /* AppDelegate.swift in Sources */,
 				82C2860C2CC90E3C000CF5F7 /* MapViewModel+CoreData.swift in Sources */,
 				82C2860A2CC90E32000CF5F7 /* TripsViewController.swift in Sources */,
 				82C2866B2CC96DB8000CF5F7 /* Notifications+Names.swift in Sources */,
+				828545382CC996900074EBF9 /* TripMapViewController.swift in Sources */,
 				82C285A22CC8E91A000CF5F7 /* TrackingAppTests.swift in Sources */,
 				82C286282CC91CBF000CF5F7 /* SpeedView.swift in Sources */,
+				828545402CC997690074EBF9 /* TripStatsView.swift in Sources */,
+				828545482CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */,
 				82C286782CC971F4000CF5F7 /* AppLocationManager+Geofencing.swift in Sources */,
 				82C285FC2CC909B0000CF5F7 /* AppLocationManager.swift in Sources */,
 				82C286562CC953B9000CF5F7 /* TransportationMode.swift in Sources */,
@@ -660,6 +694,7 @@
 				82C286162CC915BA000CF5F7 /* StatisticsViewController.swift in Sources */,
 				82C2862A2CC91CC5000CF5F7 /* EmptyStateView.swift in Sources */,
 				82C2860B2CC90E36000CF5F7 /* TripsViewController+TripCell.swift in Sources */,
+				8285453C2CC997210074EBF9 /* TripMapViewModel.swift in Sources */,
 				82C286192CC915FB000CF5F7 /* TripStatCardView.swift in Sources */,
 				82C286252CC91CB9000CF5F7 /* LocationEntity.swift in Sources */,
 				82C2865F2CC9599F000CF5F7 /* LoadingState.swift in Sources */,
@@ -676,6 +711,7 @@
 				82C286722CC97049000CF5F7 /* GeofencingService.swift in Sources */,
 				82C286332CC91FFA000CF5F7 /* XCTestCase+Helpers.swift in Sources */,
 				82C286452CC92071000CF5F7 /* LocationPermissionChecker.swift in Sources */,
+				828545452CC9979D0074EBF9 /* TripAnnotation.swift in Sources */,
 				82C286382CC92045000CF5F7 /* TripEntity+CoreDataProperties.swift in Sources */,
 				82C286492CC9207A000CF5F7 /* AppLocationManager.swift in Sources */,
 				82C285AC2CC8E91A000CF5F7 /* TrackingAppUITests.swift in Sources */,
@@ -692,9 +728,11 @@
 				82C2863E2CC92058000CF5F7 /* StatisticsViewController.swift in Sources */,
 				82C286792CC971F4000CF5F7 /* AppLocationManager+Geofencing.swift in Sources */,
 				82C2863A2CC9204C000CF5F7 /* EmptyStateView.swift in Sources */,
+				8285453D2CC997210074EBF9 /* TripMapViewModel.swift in Sources */,
 				82C2865B2CC95439000CF5F7 /* CoreDataManager+TransportationMode.swift in Sources */,
 				82C2864C2CC92082000CF5F7 /* MapCoordinator.swift in Sources */,
 				82C286462CC92073000CF5F7 /* LocationPermissionAlert.swift in Sources */,
+				828545412CC997690074EBF9 /* TripStatsView.swift in Sources */,
 				82C2863C2CC92050000CF5F7 /* TripStatCardView.swift in Sources */,
 				82C2864A2CC9207D000CF5F7 /* TripCoordinator.swift in Sources */,
 				82C286432CC92066000CF5F7 /* TripsViewModel+CoreData.swift in Sources */,
@@ -703,9 +741,11 @@
 				82C285C12CC8E9EB000CF5F7 /* MapViewModel.swift in Sources */,
 				82C286642CC96A3C000CF5F7 /* TransportationModeDetectionService.swift in Sources */,
 				82C286372CC92043000CF5F7 /* LocationEntity+CoreDataProperties.swift in Sources */,
+				828545392CC996900074EBF9 /* TripMapViewController.swift in Sources */,
 				82C2864B2CC9207F000CF5F7 /* StatisticsCoordinator.swift in Sources */,
 				82C286402CC9205E000CF5F7 /* TripsViewController.swift in Sources */,
 				82C286352CC9203E000CF5F7 /* LocationEntity.swift in Sources */,
+				828545492CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */,
 				82C286472CC92075000CF5F7 /* CoreDataManager.swift in Sources */,
 				82C286422CC92063000CF5F7 /* StatisticsViewModel.swift in Sources */,
 				82C286342CC9201A000CF5F7 /* TripEntity.swift in Sources */,

--- a/TrackingApp/Core/Coordinators/AppCoordinator.swift
+++ b/TrackingApp/Core/Coordinators/AppCoordinator.swift
@@ -1,3 +1,10 @@
+//
+//  AppCoordinator.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
 import UIKit
 
 final class AppCoordinator: Coordinator {
@@ -79,14 +86,10 @@ final class AppCoordinator: Coordinator {
             selectedImage: UIImage(systemName: "chart.bar.fill")?.withRenderingMode(.alwaysTemplate)
         )
         
-        let viewControllers = [
-            mapViewController,
-            tripsViewController,
-            statisticsViewController
-        ]
-        
-        tabBarController.setViewControllers(viewControllers, animated: false)
-        tabBarController.selectedIndex = 0
+        tabBarController.setViewControllers(
+            [mapViewController, tripsViewController, statisticsViewController],
+            animated: false
+        )
     }
 }
 

--- a/TrackingApp/Core/Coordinators/TripCoordinator.swift
+++ b/TrackingApp/Core/Coordinators/TripCoordinator.swift
@@ -8,13 +8,55 @@
 import UIKit
 
 final class TripsCoordinator: Coordinator {
-    func createViewController() -> UIViewController {
-        let viewModel = TripsViewModel()
-        let viewController = TripsViewController(viewModel: viewModel)
-        return viewController
+    // MARK: - Properties
+    
+    private let navigationController: UINavigationController
+    private var tripsViewController: TripsViewController?
+    
+    // MARK: - Initialization
+    
+    init(navigationController: UINavigationController = UINavigationController()) {
+        self.navigationController = navigationController
+        self.setupNavigationBarAppearance()
     }
     
+    private func setupNavigationBarAppearance() {
+        // Create a new appearance
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground() // Makes background opaque
+        
+        // Set the background color of the navigation bar
+        appearance.backgroundColor = .systemBackground // Or any other color you want
+
+        // Apply the appearance to the current navigation bar
+        navigationController.navigationBar.standardAppearance = appearance
+        navigationController.navigationBar.scrollEdgeAppearance = appearance
+        
+        // Ensure the background color extends to the top
+        navigationController.navigationBar.compactAppearance = appearance
+    }
+    
+    // MARK: - Coordinator
+    
     func start() {
-        // Implementation for deeper navigation if needed
+        let viewModel = TripsViewModel()
+        let viewController = TripsViewController(viewModel: viewModel)
+        viewController.coordinator = self
+        viewController.title = "Trips"
+        tripsViewController = viewController
+        navigationController.pushViewController(viewController, animated: false)
+    }
+    
+    func createViewController() -> UIViewController {
+        start()
+        return navigationController
+    }
+    
+    // MARK: - Navigation
+    
+    func showTripDetails(for trip: Trip) {
+        let viewModel = TripMapViewModel(trip: trip)
+        let viewController = TripMapViewController(viewModel: viewModel)
+        navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/TrackingApp/Core/Services/CoreDataManager+Locations.swift
+++ b/TrackingApp/Core/Services/CoreDataManager+Locations.swift
@@ -1,0 +1,40 @@
+//
+//  CoreDataManager+Locations.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
+import Combine
+import CoreData
+import Foundation
+
+// CoreDataManager+Locations.swift
+extension CoreDataManager {
+    func fetchLocations(for trip: Trip) -> AnyPublisher<[Location], Error> {
+        let context = persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<TripEntity> = TripEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", trip.id as CVarArg)
+        
+        return Future { promise in
+            context.perform {
+                do {
+                    let results = try context.fetch(fetchRequest)
+                    guard let tripEntity = results.first,
+                          let locationEntities = tripEntity.locations
+                    else {
+                        promise(.success([]))
+                        return
+                    }
+                    
+                    let locations = locationEntities.map { Location(from: $0) }
+                        .sorted { $0.timestamp < $1.timestamp }
+                    
+                    promise(.success(locations))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+}

--- a/TrackingApp/Core/Services/CoreDataManager.swift
+++ b/TrackingApp/Core/Services/CoreDataManager.swift
@@ -13,7 +13,7 @@ import UIKit
 final class CoreDataManager {
     static let shared = CoreDataManager()
     
-    private let persistentContainer: NSPersistentContainer
+    public let persistentContainer: NSPersistentContainer
     var currentTrip: TripEntity?
     
     private init() {

--- a/TrackingApp/Core/ViewModels/TripMapViewModel.swift
+++ b/TrackingApp/Core/ViewModels/TripMapViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  TripMapViewModel.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
+import Combine
+import CoreLocation
+
+final class TripMapViewModel {
+    struct TripDetails: Equatable {
+        static func == (lhs: TripMapViewModel.TripDetails, rhs: TripMapViewModel.TripDetails) -> Bool {
+            lhs.trip.id == rhs.trip.id
+        }
+        
+        let trip: Trip
+        let routeCoordinates: [CLLocationCoordinate2D]
+    }
+    
+    // MARK: - Properties
+    
+    @Published private(set) var state: LoadingState<TripDetails> = .loading
+    private let trip: Trip
+    private var cancellables = Set<AnyCancellable>()
+
+    
+    // MARK: - Initialization
+    
+    init(trip: Trip) {
+        self.trip = trip
+    }
+    
+    // MARK: - Public Methods
+    
+    func loadTripDetails() {
+        state = .loading
+        
+        CoreDataManager.shared.fetchLocations(for: trip)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.state = .error(error)
+                }
+            } receiveValue: { [weak self] locations in
+                guard let self = self else { return }
+                let coordinates = locations.map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) }
+                let details = TripDetails(trip: self.trip, routeCoordinates: coordinates)
+                self.state = .loaded(details)
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/TrackingApp/ViewControllers/TripMapViewController.swift
+++ b/TrackingApp/ViewControllers/TripMapViewController.swift
@@ -1,0 +1,214 @@
+//
+//  TripMapViewController.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
+import UIKit
+import MapKit
+import Combine
+
+final class TripMapViewController: UIViewController {
+    // MARK: - Properties
+    
+    private let viewModel: TripMapViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    private let mapView: MKMapView = {
+        let map = MKMapView()
+        map.translatesAutoresizingMaskIntoConstraints = false
+        map.showsUserLocation = false
+        return map
+    }()
+    
+    private let statsView: TripStatsView = {
+        let view = TripStatsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let loadingView: LoadingView = {
+        let view = LoadingView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    // MARK: - Initialization
+    
+    init(viewModel: TripMapViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        mapView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupBindings()
+        viewModel.loadTripDetails()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        title = "Trip Details"
+        
+        view.addSubview(mapView)
+        view.addSubview(statsView)
+        view.addSubview(loadingView)
+        
+        NSLayoutConstraint.activate([
+            mapView.topAnchor.constraint(equalTo: view.topAnchor),
+            mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mapView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.7),
+            
+            statsView.topAnchor.constraint(equalTo: mapView.bottomAnchor),
+            statsView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            statsView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            statsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            loadingView.topAnchor.constraint(equalTo: view.topAnchor),
+            loadingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            loadingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            loadingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    private func setupBindings() {
+        viewModel.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.handleState(state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleState(_ state: LoadingState<TripMapViewModel.TripDetails>) {
+        switch state {
+        case .loading:
+            showLoadingView()
+        case .loaded(let details):
+            showTripDetails(details)
+        case .empty:
+            showEmptyState()
+        case .error(let error):
+            showError(error)
+        }
+    }
+    
+    private func showLoadingView() {
+        loadingView.startAnimating()
+        loadingView.isHidden = false
+        mapView.isHidden = true
+        statsView.isHidden = true
+    }
+    
+    private func showTripDetails(_ details: TripMapViewModel.TripDetails) {
+        loadingView.stopAnimating()
+        loadingView.isHidden = true
+        mapView.isHidden = false
+        statsView.isHidden = false
+        
+        // Update map
+        addRouteOverlay(for: details.routeCoordinates)
+        centerMapOnRoute(details.routeCoordinates)
+        
+        // Update stats
+        statsView.configure(with: details.trip)
+    }
+    
+    private func showEmptyState() {
+        loadingView.stopAnimating()
+        showError(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "No trip data available"]))
+    }
+    
+    private func showError(_ error: Error) {
+        loadingView.stopAnimating()
+        let alert = UIAlertController(
+            title: "Error",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+    
+    private func addRouteOverlay(for coordinates: [CLLocationCoordinate2D]) {
+        mapView.removeOverlays(mapView.overlays)
+        
+        let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+        mapView.addOverlay(polyline)
+        
+        // Add start and end annotations
+        if let first = coordinates.first, let last = coordinates.last {
+            let startAnnotation = TripAnnotation(
+                coordinate: first,
+                title: "Start",
+                subtitle: nil,
+                type: .start
+            )
+            
+            let endAnnotation = TripAnnotation(
+                coordinate: last,
+                title: "End",
+                subtitle: nil,
+                type: .end
+            )
+            
+            mapView.addAnnotations([startAnnotation, endAnnotation])
+        }
+    }
+    
+    private func centerMapOnRoute(_ coordinates: [CLLocationCoordinate2D]) {
+        let rect = coordinates.reduce(MKMapRect.null) { rect, coordinate in
+            let point = MKMapPoint(coordinate)
+            let pointRect = MKMapRect(x: point.x, y: point.y, width: 0, height: 0)
+            return rect.union(pointRect)
+        }
+        
+        let insets = UIEdgeInsets(top: 50, left: 50, bottom: 50, right: 50)
+        mapView.setVisibleMapRect(rect, edgePadding: insets, animated: true)
+    }
+}
+
+// MARK: - MKMapViewDelegate
+
+extension TripMapViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if let polyline = overlay as? MKPolyline {
+            let renderer = MKPolylineRenderer(polyline: polyline)
+            renderer.strokeColor = .systemBlue
+            renderer.lineWidth = 4
+            return renderer
+        }
+        return MKOverlayRenderer(overlay: overlay)
+    }
+    
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard let tripAnnotation = annotation as? TripAnnotation else { return nil }
+        
+        let identifier = "TripAnnotation"
+        let annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+        
+        switch tripAnnotation.type {
+        case .start:
+            annotationView.markerTintColor = .systemGreen
+            annotationView.glyphImage = UIImage(systemName: "flag.fill")
+        case .end:
+            annotationView.markerTintColor = .systemRed
+            annotationView.glyphImage = UIImage(systemName: "flag.checkered")
+        }
+        
+        return annotationView
+    }
+}
+

--- a/TrackingApp/ViewControllers/TripsViewController.swift
+++ b/TrackingApp/ViewControllers/TripsViewController.swift
@@ -12,6 +12,7 @@ final class TripsViewController: UIViewController {
     private let viewModel: TripsViewModel
     private let tableView = UITableView()
     private var cancellables = Set<AnyCancellable>()
+    weak var coordinator: TripsCoordinator?
     
     lazy var loadingView: LoadingView = {
         let view = LoadingView()
@@ -205,5 +206,13 @@ extension TripsViewController: UITableViewDelegate {
         }
         
         viewModel.deleteTrip(trips[indexPath.row])
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard case .loaded(let trips) = viewModel.state else { return }
+        let trip = trips[indexPath.row]
+        coordinator?.showTripDetails(for: trip)
     }
 }

--- a/TrackingApp/Views/TripAnnotation.swift
+++ b/TrackingApp/Views/TripAnnotation.swift
@@ -1,0 +1,31 @@
+//
+//  TripAnnotation.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
+import CoreLocation
+import MapKit
+import UIKit
+
+// TripAnnotation.swift
+final class TripAnnotation: NSObject, MKAnnotation {
+    enum AnnotationType {
+        case start
+        case end
+    }
+    
+    let coordinate: CLLocationCoordinate2D
+    let title: String?
+    let subtitle: String?
+    let type: AnnotationType
+    
+    init(coordinate: CLLocationCoordinate2D, title: String?, subtitle: String?, type: AnnotationType) {
+        self.coordinate = coordinate
+        self.title = title
+        self.subtitle = subtitle
+        self.type = type
+        super.init()
+    }
+}

--- a/TrackingApp/Views/TripStatsView.swift
+++ b/TrackingApp/Views/TripStatsView.swift
@@ -1,0 +1,79 @@
+//
+//  TripStatsView.swift
+//  TrackingApp
+//
+//  Created by Jose on 23/10/2024.
+//
+
+import UIKit
+
+// TripStatsView.swift
+final class TripStatsView: UIView {
+    // MARK: - UI Components
+    
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+        return stack
+    }()
+    
+    private let dateLabel = UILabel()
+    private let distanceLabel = UILabel()
+    private let durationLabel = UILabel()
+    private let speedLabel = UILabel()
+    private let transportModeLabel = UILabel()
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        
+        addSubview(stackView)
+        [dateLabel, distanceLabel, durationLabel, speedLabel, transportModeLabel].forEach {
+            $0.font = .systemFont(ofSize: 16)
+            stackView.addArrangedSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    // MARK: - Configuration
+    
+    func configure(with trip: Trip) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+        dateLabel.text = "📅 Date: " + dateFormatter.string(from: trip.startDate)
+        
+        distanceLabel.text = "📍 Distance: " + String(format: "%.1f km", trip.distance / 1000)
+        
+        let duration = (trip.endDate ?? .now).timeIntervalSince(trip.startDate)
+        let hours = Int(duration) / 3600
+        let minutes = Int(duration) / 60 % 60
+        durationLabel.text = "⏱ Duration: " + String(format: "%dh %dm", hours, minutes)
+        
+        speedLabel.text = "⚡️ Average Speed: " + String(format: "%.0f km/h", trip.averageSpeed)
+        
+        transportModeLabel.text = "🚗 Mode: " + trip.transportationMode.displayName
+    }
+}


### PR DESCRIPTION
Key changes made:

TripsCoordinator:


Added navigationController property
Created navigation stack
Added method to show trip details
Returns navigationController as root view controller


TripsViewController:


Added coordinator property
Delegates navigation to coordinator
Removed direct navigation logic


AppCoordinator:

Uses coordinator's createViewController method
Each tab is now properly wrapped in its own navigation stack

This implementation follows the MVVM-C pattern where:

Coordinator handles navigation flow
ViewControllers handle view logic
ViewModels handle business logic

The navigation hierarchy is now:
CopyTabBarController
  ├─ NavigationController (Map)
  ├─ NavigationController (Trips)
   │   └─ TripsViewController
   │      └─ TripMapViewController (when selected)
  └─ NavigationController (Statistics)