### PR TITLE
Added navigation bar and reset functionality and mode indicator to map screen

### DIFF
--- a/TrackingApp.xcodeproj/project.pbxproj
+++ b/TrackingApp.xcodeproj/project.pbxproj
@@ -24,6 +24,12 @@
 		828545492CC998230074EBF9 /* CoreDataManager+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */; };
 		828545582CCBC3C20074EBF9 /* SpeedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545572CCBC3C20074EBF9 /* SpeedViewTests.swift */; };
 		8285455A2CCBC3E40074EBF9 /* TripModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545592CCBC3E40074EBF9 /* TripModelTests.swift */; };
+		8285455E2CCBCC680074EBF9 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285455D2CCBCC680074EBF9 /* PaddedLabel.swift */; };
+		8285455F2CCBCC6C0074EBF9 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285455D2CCBCC680074EBF9 /* PaddedLabel.swift */; };
+		828545602CCBCC6D0074EBF9 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8285455D2CCBCC680074EBF9 /* PaddedLabel.swift */; };
+		828545632CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545622CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift */; };
+		828545642CCBCF110074EBF9 /* StatisticsViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545622CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift */; };
+		828545652CCBCF110074EBF9 /* StatisticsViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545622CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift */; };
 		82C285882CC8E918000CF5F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C285872CC8E918000CF5F7 /* AppDelegate.swift */; };
 		82C2858A2CC8E918000CF5F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C285892CC8E918000CF5F7 /* SceneDelegate.swift */; };
 		82C285922CC8E918000CF5F7 /* TrackingApp.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 82C285902CC8E918000CF5F7 /* TrackingApp.xcdatamodeld */; };
@@ -175,6 +181,8 @@
 		828545462CC998230074EBF9 /* CoreDataManager+Locations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataManager+Locations.swift"; sourceTree = "<group>"; };
 		828545572CCBC3C20074EBF9 /* SpeedViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedViewTests.swift; sourceTree = "<group>"; };
 		828545592CCBC3E40074EBF9 /* TripModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripModelTests.swift; sourceTree = "<group>"; };
+		8285455D2CCBCC680074EBF9 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
+		828545622CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatisticsViewController+Menu.swift"; sourceTree = "<group>"; };
 		82C285842CC8E918000CF5F7 /* TrackingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TrackingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82C285872CC8E918000CF5F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		82C285892CC8E918000CF5F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -329,6 +337,7 @@
 			isa = PBXGroup;
 			children = (
 				82C286142CC915BA000CF5F7 /* StatisticsViewController.swift */,
+				828545622CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift */,
 			);
 			path = StatisticViewController;
 			sourceTree = "<group>";
@@ -367,6 +376,14 @@
 			path = StatisticsViewModel;
 			sourceTree = "<group>";
 		};
+		828545612CCBCC790074EBF9 /* Subclasses */ = {
+			isa = PBXGroup;
+			children = (
+				8285455D2CCBCC680074EBF9 /* PaddedLabel.swift */,
+			);
+			path = Subclasses;
+			sourceTree = "<group>";
+		};
 		82C2857B2CC8E918000CF5F7 = {
 			isa = PBXGroup;
 			children = (
@@ -390,14 +407,15 @@
 		82C285862CC8E918000CF5F7 /* TrackingApp */ = {
 			isa = PBXGroup;
 			children = (
-				82C285902CC8E918000CF5F7 /* TrackingApp.xcdatamodeld */,
+				82C285DD2CC8F30F000CF5F7 /* Application */,
+				82C285DE2CC8F32B000CF5F7 /* Core */,
+				82C285E52CC8F3AB000CF5F7 /* Entities */,
 				82C286732CC97096000CF5F7 /* Extensions */,
 				82C285982CC8E91A000CF5F7 /* Info.plist */,
-				82C285DD2CC8F30F000CF5F7 /* Application */,
 				82C285E62CC8F493000CF5F7 /* Resources */,
-				82C285DE2CC8F32B000CF5F7 /* Core */,
+				828545612CCBCC790074EBF9 /* Subclasses */,
+				82C285902CC8E918000CF5F7 /* TrackingApp.xcdatamodeld */,
 				82C285E32CC8F389000CF5F7 /* ViewControllers */,
-				82C285E52CC8F3AB000CF5F7 /* Entities */,
 				82C285E42CC8F394000CF5F7 /* Views */,
 			);
 			path = TrackingApp;
@@ -732,9 +750,11 @@
 				82C285EA2CC90353000CF5F7 /* TripEntity+CoreDataProperties.swift in Sources */,
 				82C2861D2CC9182D000CF5F7 /* StatisticsCoordinator.swift in Sources */,
 				82C286592CC95439000CF5F7 /* CoreDataManager+TransportationMode.swift in Sources */,
+				828545632CCBCF0E0074EBF9 /* StatisticsViewController+Menu.swift in Sources */,
 				82C285BF2CC8E9E4000CF5F7 /* MapViewController.swift in Sources */,
 				82C285F82CC9048A000CF5F7 /* TripsViewModel+CoreData.swift in Sources */,
 				82C286512CC931C0000CF5F7 /* StatCardView.swift in Sources */,
+				8285455E2CCBCC680074EBF9 /* PaddedLabel.swift in Sources */,
 				82C285C72CC8EAA0000CF5F7 /* TripsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -755,6 +775,7 @@
 				82C286212CC91C47000CF5F7 /* AppCoordinator.swift in Sources */,
 				828545442CC9979D0074EBF9 /* TripAnnotation.swift in Sources */,
 				82C286222CC91C5E000CF5F7 /* TripEntity.swift in Sources */,
+				828545642CCBCF110074EBF9 /* StatisticsViewController+Menu.swift in Sources */,
 				82C286102CC9154E000CF5F7 /* StatisticsViewModel.swift in Sources */,
 				82C2862E2CC91CE9000CF5F7 /* AppDelegate.swift in Sources */,
 				82C2860C2CC90E3C000CF5F7 /* MapViewModel+CoreData.swift in Sources */,
@@ -773,6 +794,7 @@
 				82C286242CC91CB6000CF5F7 /* TripEntity+CoreDataProperties.swift in Sources */,
 				82C285CE2CC8EB75000CF5F7 /* TripsViewModel.swift in Sources */,
 				82C2861B2CC9171E000CF5F7 /* TripStatCardViewTests.swift in Sources */,
+				8285455F2CCBCC6C0074EBF9 /* PaddedLabel.swift in Sources */,
 				82C286202CC918B2000CF5F7 /* CoordinatorTests.swift in Sources */,
 				82C2866E2CC96E5C000CF5F7 /* AppNotificationsTests.swift in Sources */,
 				82C286522CC931C0000CF5F7 /* StatCardView.swift in Sources */,
@@ -824,6 +846,7 @@
 				82C2865B2CC95439000CF5F7 /* CoreDataManager+TransportationMode.swift in Sources */,
 				82C2864C2CC92082000CF5F7 /* MapCoordinator.swift in Sources */,
 				82C286462CC92073000CF5F7 /* LocationPermissionAlert.swift in Sources */,
+				828545652CCBCF110074EBF9 /* StatisticsViewController+Menu.swift in Sources */,
 				828545412CC997690074EBF9 /* TripStatsView.swift in Sources */,
 				82C2863C2CC92050000CF5F7 /* TripStatCardView.swift in Sources */,
 				82C2864A2CC9207D000CF5F7 /* TripCoordinator.swift in Sources */,
@@ -841,6 +864,7 @@
 				82C286472CC92075000CF5F7 /* CoreDataManager.swift in Sources */,
 				82C286422CC92063000CF5F7 /* StatisticsViewModel.swift in Sources */,
 				82C286342CC9201A000CF5F7 /* TripEntity.swift in Sources */,
+				828545602CCBCC6D0074EBF9 /* PaddedLabel.swift in Sources */,
 				82C2864E2CC92088000CF5F7 /* SceneDelegate.swift in Sources */,
 				82C286312CC91FD7000CF5F7 /* MockDataHelper.swift in Sources */,
 				82C286442CC9206B000CF5F7 /* MapViewModel+CoreData.swift in Sources */,

--- a/TrackingApp/Core/Coordinators/StatisticsCoordinator.swift
+++ b/TrackingApp/Core/Coordinators/StatisticsCoordinator.swift
@@ -11,13 +11,32 @@
 import UIKit
 
 final class StatisticsCoordinator: Coordinator {
-    func createViewController() -> UIViewController {
-        let viewModel = StatisticsViewModel()
-        let viewController = StatisticsViewController(viewModel: viewModel)
-        return viewController
+    private let navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController = UINavigationController()) {
+        self.navigationController = navigationController
+        setupNavigationBarAppearance()
+    }
+    
+    private func setupNavigationBarAppearance() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .systemBackground
+        
+        navigationController.navigationBar.standardAppearance = appearance
+        navigationController.navigationBar.scrollEdgeAppearance = appearance
+        navigationController.navigationBar.compactAppearance = appearance
     }
     
     func start() {
-        // Implementation for deeper navigation if needed
+        let viewModel = StatisticsViewModel()
+        let viewController = StatisticsViewController(viewModel: viewModel)
+        viewController.title = "Statistics"
+        navigationController.pushViewController(viewController, animated: false)
+    }
+    
+    func createViewController() -> UIViewController {
+        start()
+        return navigationController
     }
 }

--- a/TrackingApp/Core/Services/CoreDataManager/CoreDataManager.swift
+++ b/TrackingApp/Core/Services/CoreDataManager/CoreDataManager.swift
@@ -85,6 +85,19 @@ final class CoreDataManager {
         }
     }
     
+    func deleteAllTrips() {
+        let context = persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = TripEntity.fetchRequest()
+        let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        
+        do {
+            try context.execute(batchDeleteRequest)
+            saveContext()
+        } catch {
+            print("Error deleting all trips: \(error)")
+        }
+    }
+    
     // MARK: - Private Methods
     
     private func calculateTripStatistics(_ trip: TripEntity) {

--- a/TrackingApp/Subclasses/PaddedLabel.swift
+++ b/TrackingApp/Subclasses/PaddedLabel.swift
@@ -1,0 +1,23 @@
+//
+//  PaddedLabel.swift
+//  TrackingApp
+//
+//  Created by Jose on 25/10/2024.
+//
+
+import UIKit
+
+final class PaddedLabel: UILabel {
+    var contentEdgeInsets = UIEdgeInsets.zero
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: contentEdgeInsets))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        size.width += contentEdgeInsets.left + contentEdgeInsets.right
+        size.height += contentEdgeInsets.top + contentEdgeInsets.bottom
+        return size
+    }
+}

--- a/TrackingApp/ViewControllers/StatisticViewController/StatisticsViewController+Menu.swift
+++ b/TrackingApp/ViewControllers/StatisticViewController/StatisticsViewController+Menu.swift
@@ -1,0 +1,49 @@
+//
+//  StatisticsViewController+Menu.swift
+//  TrackingApp
+//
+//  Created by Jose on 25/10/2024.
+//
+
+import UIKit
+
+extension StatisticsViewController {
+    func setupNavigationMenu() {
+        let menu = UIMenu(title: "", options: .displayInline, children: [
+            UIAction(
+                title: "Reset All Data",
+                image: UIImage(systemName: "trash"),
+                attributes: .destructive
+            ) { [weak self] _ in
+                self?.showResetConfirmation()
+            }
+        ])
+        
+        let menuButton = UIBarButtonItem(
+            image: UIImage(systemName: "ellipsis.circle"),
+            menu: menu
+        )
+        
+        navigationItem.rightBarButtonItem = menuButton
+    }
+    
+    private func showResetConfirmation() {
+        let alert = UIAlertController(
+            title: "Reset All Data",
+            message: "This will permanently delete all your trips. This action cannot be undone.",
+            preferredStyle: .actionSheet
+        )
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Reset", style: .destructive) { [weak self] _ in
+            self?.resetAllData()
+        })
+        
+        present(alert, animated: true)
+    }
+    
+    private func resetAllData() {
+        CoreDataManager.shared.deleteAllTrips()
+        viewModel.loadStatistics()
+    }
+}

--- a/TrackingApp/ViewControllers/StatisticViewController/StatisticsViewController.swift
+++ b/TrackingApp/ViewControllers/StatisticViewController/StatisticsViewController.swift
@@ -12,7 +12,7 @@ import Combine
 import UIKit
 
 final class StatisticsViewController: UIViewController {
-    private let viewModel: StatisticsViewModel
+    public let viewModel: StatisticsViewModel
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Components
@@ -69,6 +69,7 @@ final class StatisticsViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         setupBindings()
+        setupNavigationMenu()
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
# Add Transport Mode Label & Statistics Settings Menu

## Changes
- Added real-time transportation mode indicator to Map screen
- Implemented settings menu in Statistics screen with data reset capability
- Added navigation controller to Statistics screen

## Implementation Details
- Transportation mode label shows current activity (walking/cycling/automotive) with corresponding colors
- Settings menu uses native UIMenu for better iOS integration
- Added confirmation alert before data reset
- Reused existing CoreData infrastructure for data deletion

## Technical Details
- Used Combine for reactive transportation mode updates
- Implemented custom PaddedLabel for better visual appearance
- Added batch delete operation for efficient data cleanup
- Maintained MVVM-C architecture patterns

## Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-10-25 at 15 12 57](https://github.com/user-attachments/assets/ca95defa-1fd2-42db-8f25-4044da314c46)
![Simulator Screenshot - iPhone 15 Pro - 2024-10-25 at 15 13 15](https://github.com/user-attachments/assets/1a346314-26c7-4c14-9ee2-410825a53c1b)
![Simulator Screenshot - iPhone 15 Pro - 2024-10-25 at 15 13 51](https://github.com/user-attachments/assets/b70dcce6-0ef2-46eb-9f7d-84f82c6f4d54)


## Testing
- Verified mode label updates correctly with activity changes
- Tested data reset functionality
- Confirmed navigation appearance matches app style
- Verified alert confirmation prevents accidental data loss

## Security
- Data reset protected behind confirmation dialog
- Using system batch delete operations for data integrity

## Dependencies
- No new dependencies added